### PR TITLE
Centralized Terraform state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate
 *.tfstate.*
 *.tfvars
+*.tfvars.json
 **/.terraform/*
 /infra/get-mfa-vars.sh
 /web/node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ".enc.json$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/infra/.sops.yaml
+++ b/infra/.sops.yaml
@@ -1,0 +1,2 @@
+creation_rules:
+  - kms: "arn:aws:kms:eu-central-1:631260641272:alias/tarmo"

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,6 +9,7 @@ Run these steps the first time.
    see [AWS Configuration basics](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config)
    and [Where are the configuration settings stored](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
    for more info)
+3. Optionally, install [sops](https://github.com/mozilla/sops) to decrypt encrypted variable files in the repository.
 
 ### Multi-factor authentication (MFA)
 
@@ -19,12 +20,12 @@ and finally run `. /tmp/aws-mfa-token` to temporarily set the correct MFA enviro
 
 ## Configuration
 
-1. Copy [tfvars.example](tfvars.example) to a new file called `tarmo.tfvars`
+1. Decrypt `tarmo.tfvars.enc.json` by running `sops -d tarmo.tfvars.enc.json > tarmo.tfvars.json`. Alternatively, copy [tfvars.sample.json](tfvars.sample.json) to a new file called `tarmo.tfvars.json`
 2. Create two new IAM users for CI/CD and take down the username and credentials. These users can be used to configure CD deployment from
    Github. If CD is already configured, use existing users:
-   1. User to upload frontend to S3. Fill this user in `AWS_S3_USER` part in `tarmo.tfvars`. Fill credentials in Github secrets `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-   2. User to update lambda functions. Fill this user in `AWS_LAMBDA_USER` part in `tarmo.tfvars`. Fill credentials in Github secrets `AWS_LAMBDA_UPLOAD_ACCESS_KEY_ID` and `AWS_LAMBDA_UPLOAD_SECRET_ACCESS_KEY`.
-3. Change the values in `tarmo.tfvars` as required
+   1. User to upload frontend to S3. Fill this user in `AWS_S3_USER` part in `tarmo.tfvars.json`. Fill credentials in Github secrets `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+   2. User to update lambda functions. Fill this user in `AWS_LAMBDA_USER` part in `tarmo.tfvars.json`. Fill credentials in Github secrets `AWS_LAMBDA_UPLOAD_ACCESS_KEY_ID` and `AWS_LAMBDA_UPLOAD_SECRET_ACCESS_KEY`.
+3. Change the values in `tarmo.tfvars.json` as required
 4. Create zip packages for the lambda functions by running `make build-lambda -C ..` (this
    has to be done only once since github actions can be configured to update functions).
 
@@ -34,7 +35,7 @@ To launch the instances, run the following commands:
 
 ```shell
 terraform init
-terraform apply -var-file tarmo.tfvars
+terraform apply --var-file tarmo.tfvars.json
 ```
 
 Note: Setting up the instances takes a couple of minutes.
@@ -44,7 +45,7 @@ Take down the following outputs:
 - **frontend_route53_dns_record**
 - **tileserver_route53_dns_record**
 
-Shut down and destroy the instances with `terraform destroy -var-file tarmo.tfvars`
+Shut down and destroy the instances with `terraform destroy --var-file tarmo.tfvars.json`
 
 ## Manual interactions
 

--- a/infra/state.tf
+++ b/infra/state.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-gispo"
+    key = "tarmo.tfstate"
+    region = "eu-central-1"
+    encrypt = true
+    kms_key_id = "arn:aws:kms:eu-central-1:631260641272:alias/terraform-bucket-key"
+    dynamodb_table = "terraform-state"
+    workspace_key_prefix = "tarmo"
+  }
+}

--- a/infra/tarmo.tfvars.enc.json
+++ b/infra/tarmo.tfvars.enc.json
@@ -1,0 +1,52 @@
+{
+	"AWS_REGION_NAME": "ENC[AES256_GCM,data:QdxXlX6GI1BiCOyH,iv:igB5jIKeSMTRg40/5ci9g1IbMi0JFp8eNCev0uuuyIQ=,tag:XDFh4gDvZoGr+dtkUd394g==,type:str]",
+	"AWS_BUCKET_NAME": "ENC[AES256_GCM,data:FMi3L3K7m4OAF9vb,iv:mv436zMkPGMYMlLmz1B7nNEUp4dh/ENQoin673+cO8k=,tag:gNOIE5NZur4uqhH1KglNIw==,type:str]",
+	"AWS_S3_USER": "ENC[AES256_GCM,data:E8K/TjHowW88EZPjmw==,iv:wTKWuR0yeGxSnRgfZnk65uDTke99nDv9o6CvgD4MTK8=,tag:LjZVURvk0miaShEki0o53g==,type:str]",
+	"AWS_LAMBDA_USER": "ENC[AES256_GCM,data:AxEDVhBiEAFCZQtDE40HppaBxwjmeZEj,iv:woIfxKDkRghgU/llTGvqCD1bQIF44YqTUc5HdRgjMKQ=,tag:150t6p3UaKAliAraWeh5CQ==,type:str]",
+	"AWS_HOSTED_DOMAIN": "ENC[AES256_GCM,data:PNPJN9MspFHjrYuO6nc=,iv:+LzB6xhTxNJ28lUZOBDACxCWFUNhEeOOjZYLXlEqdCk=,tag:vzmWemv2y7pnNaMMRTfHnw==,type:str]",
+	"enable_route53_record": "ENC[AES256_GCM,data:/EwI5g==,iv:OmBwJvzoNW2tUsG5ZzOQibMa5r7sZljgTft5CGZ5CBM=,tag:xVu/J6ldiY/cAnlHSNcoaQ==,type:bool]",
+	"frontend_subdomain": "ENC[AES256_GCM,data:GDU8jxw=,iv:h5K1OgHVlejKGkpj8fE7p0kb4oOQqMBlsOh/Q05pVAU=,tag:g3NnUjPJLqwU81gzp0I1hw==,type:str]",
+	"backend_subdomain": "ENC[AES256_GCM,data:a46EAMfiW/aK9eHQkOAsNKU=,iv:DxPRpZWBBDIKGnWa1jtZewm7Or5A/il7ldtBHQNKuXY=,tag:IFHO79K12Z+h1zmjO3CPEg==,type:str]",
+	"tarmo_db_name": "ENC[AES256_GCM,data:I6f7o0o=,iv:H5OiW0XtQ2DmOkrGd43p6RNNeRIWsTTv+j5nRVAMZhQ=,tag:XDgO+DP4Wo/mJGVYVemCAA==,type:str]",
+	"su_secrets": {
+		"username": "ENC[AES256_GCM,data:7SvqgNvnOPU=,iv:/In8EM97AJgh3Ze2cQgozH1IWIKVRWEct7Ou0hjHAAk=,tag:4Ez6swQGEvSt8GQSngJAbg==,type:str]",
+		"password": "ENC[AES256_GCM,data:oWMgyUDqtnowDa0KvAZloQETZjcs4wKLn6Rp15UpP0TrtXg3vYbtFYj+Q1Q7bVOzJoXFcXx24u3pSFzy+yeWp/RNdb5/We67gJaPB9e+L7p7iMePFwd6xhQlCuFZO1zSuLTW,iv:a/MagfPwUVp5NMmlkkoPt5UM0J95YV25nC8HvEQYLhw=,tag:W0Lmr2BvYw3jgh0ZXzgnyA==,type:str]"
+	},
+	"tarmo_admin_secrets": {
+		"username": "ENC[AES256_GCM,data:b1SfZWJwP57IJF0=,iv:YL1mRipj3zXk+FYdE77CVhZ1dkjr6gViKTG1Xtc229Q=,tag:qKnXsa/frytXqtbMmGVUaA==,type:str]",
+		"password": "ENC[AES256_GCM,data:6qHzRWutotGypysBpeH1TAhJQ48ajyDiFuiutuJmTFFBLCzm6FvY6gueWDfEmp5mJBj+rZzpgucd61zM74gG4RgdLWbT4aSYmrDprI08avRneQ3p22Nbzz85GaOfUiFw4KH3,iv:vhJt/Zx264eKEafP7pJ+TsNq/uDUK7kLrvpovxcQsZc=,tag:hAzU4CuFQ2BUkTyDoNnygg==,type:str]"
+	},
+	"tarmo_r_secrets": {
+		"username": "ENC[AES256_GCM,data:6Xq96/G7eZY39w==,iv:bBRJMp/Ite/Oy/2E9uXWIifMlMFCrZgrmgtDXfaWYcA=,tag:KOcoJnVv0Bi5truXKfk+fw==,type:str]",
+		"password": "ENC[AES256_GCM,data:WbYMLJlHjTWQGsoMegihf1ywpSQqamjaLbhEzYKPkChIdw4xZeuwCnd7NSvhTgBrfiX8NoG37Q==,iv:2Gw21Mi5K2CsaKhNZu61eF772mILrZjYVBRAvtackNU=,tag:D8EK+Jgak5UgMwZqsbXUQA==,type:str]"
+	},
+	"tarmo_rw_secrets": {
+		"username": "ENC[AES256_GCM,data:vRcV5L7xFR6HHXWZS1VmIQ==,iv:U/8YAMdpC73MyBUvIX3YZ6oPQEgv8MuK90ZbJEJc42w=,tag:UHCCTbTO+LAOZFGxBWnC2A==,type:str]",
+		"password": "ENC[AES256_GCM,data:+1NEC2JZnopYdfeko7qFXENXc3KyPcT7tIgI6NhPn0/Eaxbx7W8z7Qy5hLciZSVyKYMzUBeFnKKGkVhYJ990vSrPXHGh+RViekVZy7cEtQxUhT0=,iv:jb/vUe1775q3EaYQ6ncc2aL7F7ksH8sJ0k2hQupvEFs=,tag:d2eZISk/Dy7Sfnlwr816RQ==,type:str]"
+	},
+	"prefix": "ENC[AES256_GCM,data:e8al+gM=,iv:SH33UBfqEGGqqSmQg6WI8M4L9x+/hGlFf4l8qLNL2hM=,tag:EhxvufwxHKKGmsZfQal6Sw==,type:str]",
+	"extra_tags": {
+		"Customer": "ENC[AES256_GCM,data:RhMlXZoKCA==,iv:1hXxsXw66l/Addy535jXsmsaWJ+TKUsSsJnfl62yE4s=,tag:prpY/3D+BR0jx6eK3RoC7g==,type:str]",
+		"Project": "ENC[AES256_GCM,data:7NG2r5Q=,iv:C1pRcPIwrxJO7IDYDEQ3h/cP7fD63j81IhoD5p5ucXQ=,tag:2Atvd4AEUMBBcdKHS15t5g==,type:str]",
+		"wrike_task_id": "ENC[AES256_GCM,data:lupnrsMeT6PG,iv:PbCShar06pTGoJgwkoxe3kDtXbCoEaXVYK2zp7CZeAo=,tag:rqkpmLk+n2n+xepSVI58ag==,type:str]"
+	},
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:eu-central-1:631260641272:alias/tarmo",
+				"created_at": "2022-02-11T08:58:05Z",
+				"enc": "AQICAHirjGJTwriRmzrCm4Ko5h27PicsdOnESPKi/rx8N8pppwEpay95JCnmwzT/fV7WelruAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMD7Fs3SdTU1OUNUJ0AgEQgDvH1PKHHw1nn5oKfOTwwsf39cp83YPud4YQ5TYqpkwlLRYNV4Sa9h1no9fBcC6VHEUTN3slzJMJEnq24A==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-02-11T08:58:05Z",
+		"mac": "ENC[AES256_GCM,data:7Vw39pAef+CjvRtk5Be7JtPxJWqFAZKqOxVaYvFC1V4qn8onta+ZwCuR/oGTcUKff/8hJ7oadqfMTqHhrxO7vtBaSyMCguSy6lQB5c6BIasZ/detLGPpiP1MJezPtsTi7hfqwB1n+bhlkv3AtbD18M3vZU5FLsFeKhNSRS2FY7E=,iv:qiHv1BCzSaeokgT5YDJLo7i3WlWSFqwTnIQ2Tf9xYTA=,tag:ZOM9bm5gTgpsHdWqL4mJOA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.1"
+	}
+}

--- a/infra/tfvars.example
+++ b/infra/tfvars.example
@@ -1,7 +1,0 @@
-AWS_REGION_NAME="<AWS Region name>"
-AWS_BUCKET_NAME="<AWS S3 bucket name>"
-AWS_S3_USER="<AWS S3 user name>"
-AWS_HOSTED_DOMAIN="<Domain for create route53 record>"
-
-enable_route53_record=false
-frontend_subdomain="<Name of the site, used for example in <SITE_NAME>.domain.com>"

--- a/infra/tfvars.sample.json
+++ b/infra/tfvars.sample.json
@@ -1,0 +1,8 @@
+{
+  "AWS_REGION_NAME": "<AWS Region name>",
+  "AWS_BUCKET_NAME": "<AWS S3 bucket name>",
+  "AWS_S3_USER": "<AWS S3 user name>",
+  "AWS_HOSTED_DOMAIN": "<Domain for create route53 record>",
+  "enable_route53_record": false,
+  "frontend_subdomain": "<Name of the site, used for example in <SITE_NAME>.domain.com>"
+}


### PR DESCRIPTION
Use the S3 backend for keeping track of Terraform state. Store encrypted tfvars in repository with sops.

Closes #44 