### PR TITLE
Add first version of clustering points in database; fix #37

### DIFF
--- a/backend/databasemodel/alembic/versions/f10f72c08c61/downgrade.sql
+++ b/backend/databasemodel/alembic/versions/f10f72c08c61/downgrade.sql
@@ -1,0 +1,14 @@
+DROP INDEX kooste.lipas_pisteet_tarmo_category_idx;
+DROP INDEX kooste.lipas_viivat_tarmo_category_idx;
+DROP INDEX kooste.osm_pisteet_tarmo_category_idx;
+DROP INDEX kooste.osm_alueet_tarmo_category_idx;
+DROP INDEX kooste.tamperewfs_luonnonmuistomerkit_tarmo_category_idx;
+DROP INDEX kooste.tamperewfs_luontopolkurastit_tarmo_category_idx;
+DROP INDEX kooste.tamperewfs_luontopolkureitit_tarmo_category_idx;
+DROP INDEX kooste.museovirastoarcrest_rkykohteet_tarmo_category_idx;
+DROP INDEX kooste.museovirastoarcrest_muinaisjaannokset_tarmo_category_idx;
+DROP MATERIALIZED VIEW kooste.point_clusters_8;
+DROP MATERIALIZED VIEW kooste.point_clusters_9;
+DROP MATERIALIZED VIEW kooste.point_clusters_10;
+DROP MATERIALIZED VIEW kooste.point_clusters_11;
+DROP MATERIALIZED VIEW kooste.point_clusters_12;

--- a/backend/databasemodel/alembic/versions/f10f72c08c61/upgrade.sql
+++ b/backend/databasemodel/alembic/versions/f10f72c08c61/upgrade.sql
@@ -1,0 +1,111 @@
+CREATE INDEX ON kooste.lipas_pisteet (tarmo_category);
+CREATE INDEX ON kooste.lipas_viivat (tarmo_category);
+CREATE INDEX ON kooste.osm_pisteet (tarmo_category);
+CREATE INDEX ON kooste.osm_alueet (tarmo_category);
+CREATE INDEX ON kooste.tamperewfs_luonnonmuistomerkit (tarmo_category);
+CREATE INDEX ON kooste.tamperewfs_luontopolkurastit (tarmo_category);
+CREATE INDEX ON kooste.tamperewfs_luontopolkureitit (tarmo_category);
+CREATE INDEX ON kooste.museovirastoarcrest_rkykohteet (tarmo_category);
+CREATE INDEX ON kooste.museovirastoarcrest_muinaisjaannokset (tarmo_category);
+
+-- cluster lipas points, rkykohteet, luonnonmuistomerkit, muinaisjaannokset and luontopolkurastit at zoom 8
+create materialized view kooste.point_clusters_8 as
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", TRUE as visibility from (
+	select unnest(ST_ClusterWithin(geom,0.16)) as cluster, "cityName", deleted, "tarmo_category" from kooste.lipas_pisteet group by "cityName", deleted, "tarmo_category"
+) as lipas_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.16)) as cluster, deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_rkykohteet group by deleted, visibility, "tarmo_category"
+) as rkykohteet_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.16)) as cluster, "cityName", deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_muinaisjaannokset group by "cityName", deleted, visibility, "tarmo_category"
+) as muinaisjaannokset_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.16)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luonnonmuistomerkit group by deleted, visibility, "tarmo_category"
+) as luonnonmuistomerkki_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.16)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luontopolkurastit group by deleted, visibility, "tarmo_category"
+) as luontopolkurasti_clusters;
+
+-- cluster lipas points, rkykohteet, luonnonmuistomerkit, muinaisjaannokset and luontopolkurastit at zoom 9
+create materialized view kooste.point_clusters_9 as
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", TRUE as visibility from (
+	select unnest(ST_ClusterWithin(geom,0.08)) as cluster, "cityName", deleted, "tarmo_category" from kooste.lipas_pisteet group by "cityName", deleted, "tarmo_category"
+) as lipas_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.08)) as cluster, deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_rkykohteet group by deleted, visibility, "tarmo_category"
+) as rkykohteet_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.08)) as cluster, "cityName", deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_muinaisjaannokset group by "cityName", deleted, visibility, "tarmo_category"
+) as muinaisjaannokset_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.08)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luonnonmuistomerkit group by deleted, visibility, "tarmo_category"
+) as luonnonmuistomerkki_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.08)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luontopolkurastit group by deleted, visibility, "tarmo_category"
+) as luontopolkurasti_clusters;
+
+-- cluster lipas points, rkykohteet, luonnonmuistomerkit, muinaisjaannokset and luontopolkurastit at zoom 10
+create materialized view kooste.point_clusters_10 as
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", TRUE as visibility from (
+	select unnest(ST_ClusterWithin(geom,0.04)) as cluster, "cityName", deleted, "tarmo_category" from kooste.lipas_pisteet group by "cityName", deleted, "tarmo_category"
+) as lipas_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.04)) as cluster, deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_rkykohteet group by deleted, visibility, "tarmo_category"
+) as rkykohteet_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.04)) as cluster, "cityName", deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_muinaisjaannokset group by "cityName", deleted, visibility, "tarmo_category"
+) as muinaisjaannokset_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.04)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luonnonmuistomerkit group by deleted, visibility, "tarmo_category"
+) as luonnonmuistomerkki_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.04)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luontopolkurastit group by deleted, visibility, "tarmo_category"
+) as luontopolkurasti_clusters;
+
+-- cluster muinaisjaannokset and luontopolkurastit at zoom 11
+create materialized view kooste.point_clusters_11 as
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.02)) as cluster, "cityName", deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_muinaisjaannokset group by "cityName", deleted, visibility, "tarmo_category"
+) as muinaisjaannokset_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.02)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luontopolkurastit group by deleted, visibility, "tarmo_category"
+) as luontopolkurasti_clusters;
+
+-- cluster muinaisjaannokset and luontopolkurastit at zoom 12
+create materialized view kooste.point_clusters_12 as
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.01)) as cluster, "cityName", deleted, "tarmo_category", visibility from kooste.museovirastoarcrest_muinaisjaannokset group by "cityName", deleted, visibility, "tarmo_category"
+) as muinaisjaannokset_clusters union all
+select ST_NumGeometries(cluster) as size, ST_SetSRID(ST_Centroid(cluster), 4326)::geometry(point,4326) as geom, 'Tampere' as "cityName", deleted, "tarmo_category", visibility from (
+	select unnest(ST_ClusterWithin(geom,0.01)) as cluster, deleted, "tarmo_category", visibility from kooste.tamperewfs_luontopolkurastit group by deleted, visibility, "tarmo_category"
+) as luontopolkurasti_clusters;
+
+ALTER TABLE kooste.point_clusters_8 OWNER TO tarmo_read_write;
+
+ALTER TABLE kooste.point_clusters_9 OWNER TO tarmo_read_write;
+
+ALTER TABLE kooste.point_clusters_10 OWNER TO tarmo_read_write;
+
+ALTER TABLE kooste.point_clusters_11 OWNER TO tarmo_read_write;
+
+ALTER TABLE kooste.point_clusters_12 OWNER TO tarmo_read_write;
+
+GRANT SELECT
+   ON TABLE kooste.point_clusters_8
+   TO tarmo_read, tarmo_admin;
+
+GRANT SELECT
+   ON TABLE kooste.point_clusters_9
+   TO tarmo_read, tarmo_admin;
+
+GRANT SELECT
+   ON TABLE kooste.point_clusters_10
+   TO tarmo_read, tarmo_admin;
+
+GRANT SELECT
+   ON TABLE kooste.point_clusters_11
+   TO tarmo_read, tarmo_admin;
+
+GRANT SELECT
+   ON TABLE kooste.point_clusters_12
+   TO tarmo_read, tarmo_admin;

--- a/backend/databasemodel/alembic/versions/f10f72c08c61_add_cluster_views.py
+++ b/backend/databasemodel/alembic/versions/f10f72c08c61_add_cluster_views.py
@@ -1,0 +1,37 @@
+"""add cluster views
+
+Revision ID: f10f72c08c61
+Revises: b4eea63fd165
+Create Date: 2022-05-10 15:12:10.591771
+
+"""
+import os
+
+from alembic import op
+
+here = os.path.dirname(os.path.realpath(__file__))
+
+# revision identifiers, used by Alembic.
+revision = "f10f72c08c61"
+down_revision = "b4eea63fd165"
+branch_labels = None
+depends_on = None
+
+revision_dir = f"{here}/{revision}"
+
+
+# idea from https://github.com/tbobm/alembic-sequeled
+def process_migration(script_name: str):
+    filename = f"{revision_dir}/{script_name}.sql"
+
+    query = "\n".join(open(filename))
+    if len(query) > 0:
+        op.execute(query)
+
+
+def upgrade():
+    process_migration("upgrade")
+
+
+def downgrade():
+    process_migration("downgrade")

--- a/backend/test/test_arcgis_loader.py
+++ b/backend/test/test_arcgis_loader.py
@@ -2918,6 +2918,7 @@ def assert_data_is_imported(main_db_params):
     conn = psycopg2.connect(**main_db_params)
     try:
         with conn.cursor() as cur:
+            # museovirasto data should be present
             cur.execute(
                 f"SELECT count(*) FROM kooste.museovirastoarcrest_muinaisjaannokset WHERE NOT deleted"
             )
@@ -2936,6 +2937,19 @@ def assert_data_is_imported(main_db_params):
             assert cur.fetchone()[0].timestamp() == pytest.approx(
                 datetime.datetime.now().timestamp(), 20
             )
+            # muinaisjaannokset should be clustered
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_8")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_9")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_10")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_11")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_12")
+            assert cur.fetchone()[0] > 0
+
+            # syke data should be present
             cur.execute(
                 f"SELECT count(*) FROM kooste.syke_natura2000 WHERE NOT deleted"
             )

--- a/backend/test/test_lipas_loader.py
+++ b/backend/test/test_lipas_loader.py
@@ -177,6 +177,13 @@ def assert_data_is_imported(main_db_params):
             assert cur.fetchone()[0].timestamp() == pytest.approx(
                 datetime.datetime.now().timestamp(), 20
             )
+            # lipas points should be clustered at levels < 11
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_8")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_9")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_10")
+            assert cur.fetchone()[0] > 0
     finally:
         conn.close()
 

--- a/backend/test/test_wfs_loader.py
+++ b/backend/test/test_wfs_loader.py
@@ -249,6 +249,18 @@ def assert_data_is_imported(main_db_params):
             assert cur.fetchone()[0].timestamp() == pytest.approx(
                 datetime.datetime.now().timestamp(), 20
             )
+            # luontopolkurastit should be clustered
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_8")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_9")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_10")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_11")
+            assert cur.fetchone()[0] > 0
+            cur.execute(f"SELECT count(*) FROM kooste.point_clusters_12")
+            assert cur.fetchone()[0] > 0
+
     finally:
         conn.close()
 

--- a/web/src/components/InfoSlider.tsx
+++ b/web/src/components/InfoSlider.tsx
@@ -41,7 +41,7 @@ import SwipeableViews from "react-swipeable-views";
 import palette from "../theme/palette";
 import shadows from "../theme/shadows";
 import { PopupInfo } from "../types";
-import { getCategoryIcon } from "../utils";
+import { getCategoryIcon, getCategoryPlural } from "../utils";
 import PropertyListItem from "./PropertyListItem";
 
 interface PopupProps {
@@ -420,13 +420,25 @@ export default function InfoSlider({ popupInfo }: PopupProps) {
         )}
         {mobile ? (
           <Stack>
-            <Typography variant="h4">{properties["name"]}</Typography>
+            <Typography variant="h4">
+              {properties["size"]
+                ? `${properties["size"]} ${getCategoryPlural(
+                    properties["tarmo_category"]
+                  )}`
+                : properties["name"]}
+            </Typography>
             <Typography variant="body2">{properties["type_name"]}</Typography>
           </Stack>
         ) : (
           <Fade in={open}>
             <Stack>
-              <Typography variant="h4">{properties["name"]}</Typography>
+              <Typography variant="h4">
+                {properties["size"]
+                  ? `${properties["size"]} ${getCategoryPlural(
+                      properties["tarmo_category"]
+                    )}`
+                  : properties["name"]}
+              </Typography>
               <Typography variant="body2">{properties["type_name"]}</Typography>
             </Stack>
           </Fade>

--- a/web/src/components/LayerFilter.tsx
+++ b/web/src/components/LayerFilter.tsx
@@ -7,10 +7,13 @@ import {
 } from "@mui/material";
 import * as React from "react";
 import shadows from "../theme/shadows";
-import { MapFiltersContext, MapFilters } from "../contexts/MapFiltersContext";
+import {
+  MapFiltersContext,
+  CategoryFilters,
+} from "../contexts/MapFiltersContext";
 
 type Category = {
-  name: keyof MapFilters;
+  name: keyof CategoryFilters;
   tooltip: string;
   icon: string;
 };
@@ -67,17 +70,17 @@ const categories: Category[] = [
     icon: "camera-darkwater.png",
   },
   {
-    name: "pysakointi",
+    name: "Pysäköinti",
     tooltip: "Pysäköinti",
     icon: "parking-darkwater.png",
   },
   {
-    name: "pysakit",
+    name: "Pysäkit",
     tooltip: "Pysäkit",
     icon: "bus-darkwater.png",
   },
   {
-    name: "muinaisjaannokset",
+    name: "Muinaisjäännökset",
     tooltip: "Muinaisjäännökset",
     icon: "historical-dark.png",
   },

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -42,7 +42,22 @@ import {
   OSM_POINT_LABEL_STYLE,
   DIGITRANSIT_POINT_STYLE,
   DIGITRANSIT_IMAGES,
-  OSM_IMAGES,
+  POINT_IMAGES,
+  POINT_CLUSTER_8_SOURCE,
+  POINT_CLUSTER_8_STYLE_CIRCLE,
+  POINT_CLUSTER_8_STYLE_SYMBOL,
+  POINT_CLUSTER_9_SOURCE,
+  POINT_CLUSTER_9_STYLE_CIRCLE,
+  POINT_CLUSTER_9_STYLE_SYMBOL,
+  POINT_CLUSTER_10_SOURCE,
+  POINT_CLUSTER_10_STYLE_CIRCLE,
+  POINT_CLUSTER_10_STYLE_SYMBOL,
+  POINT_CLUSTER_11_SOURCE,
+  POINT_CLUSTER_11_STYLE_CIRCLE,
+  POINT_CLUSTER_11_STYLE_SYMBOL,
+  POINT_CLUSTER_12_SOURCE,
+  POINT_CLUSTER_12_STYLE_CIRCLE,
+  POINT_CLUSTER_12_STYLE_SYMBOL,
   NLS_STYLE_URI,
   NLS_LABEL_STYLE,
   NLS_KUNNAT_LABEL_STYLE,
@@ -77,7 +92,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
       LayerId.DigiTransitPoint,
       {
         url: "https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql",
-        zoomThreshold: 13,
+        zoomThreshold: 14,
         gqlQuery: `{
         stopsByBbox(minLat: $minLat, minLon: $minLon, maxLat: $maxLat, maxLon: $maxLon ) {
           vehicleType
@@ -199,7 +214,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
             mapRef.addImage(tuple[0], tuple[1])
           );
           // eslint-disable-next-line
-          OSM_IMAGES.forEach((tuple: any) =>
+          POINT_IMAGES.forEach((tuple: any) =>
             mapRef.addImage(tuple[0], tuple[1])
           );
         });
@@ -251,7 +266,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
     [setPopupFeature]
   );
 
-  const lipasFilter = mapFiltersContext.getLipasFilter();
+  const categoryFilter = mapFiltersContext.getCategoryFilter();
 
   return (
     <MapGL
@@ -276,7 +291,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
             ...OSM_AREA_STYLE,
             layout: {
               ...(OSM_AREA_STYLE as FillLayer).layout,
-              visibility: mapFiltersContext.getVisibilityValue("pysakointi"),
+              visibility: mapFiltersContext.getVisibilityValue("Pysäköinti"),
             },
           }}
         />
@@ -290,17 +305,59 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
 
       {/* Linestrings */}
       <Source id={LayerId.LipasLine} {...LIPAS_LINE_SOURCE}>
-        <Layer {...{ ...LIPAS_LINE_STYLE, filter: lipasFilter }} />
+        <Layer {...{ ...LIPAS_LINE_STYLE, filter: categoryFilter }} />
       </Source>
 
-      {/* Clickable points */}
+      {/* Clusters by zoom level 8-12 */}
+      <Source id={LayerId.PointCluster8} {...POINT_CLUSTER_8_SOURCE}>
+        <Layer
+          {...{ ...POINT_CLUSTER_8_STYLE_CIRCLE, filter: categoryFilter }}
+        />
+        <Layer
+          {...{ ...POINT_CLUSTER_8_STYLE_SYMBOL, filter: categoryFilter }}
+        />
+      </Source>
+      <Source id={LayerId.PointCluster9} {...POINT_CLUSTER_9_SOURCE}>
+        <Layer
+          {...{ ...POINT_CLUSTER_9_STYLE_CIRCLE, filter: categoryFilter }}
+        />
+        <Layer
+          {...{ ...POINT_CLUSTER_9_STYLE_SYMBOL, filter: categoryFilter }}
+        />
+      </Source>
+      <Source id={LayerId.PointCluster10} {...POINT_CLUSTER_10_SOURCE}>
+        <Layer
+          {...{ ...POINT_CLUSTER_10_STYLE_CIRCLE, filter: categoryFilter }}
+        />
+        <Layer
+          {...{ ...POINT_CLUSTER_10_STYLE_SYMBOL, filter: categoryFilter }}
+        />
+      </Source>
+      <Source id={LayerId.PointCluster11} {...POINT_CLUSTER_11_SOURCE}>
+        <Layer
+          {...{ ...POINT_CLUSTER_11_STYLE_CIRCLE, filter: categoryFilter }}
+        />
+        <Layer
+          {...{ ...POINT_CLUSTER_11_STYLE_SYMBOL, filter: categoryFilter }}
+        />
+      </Source>
+      <Source id={LayerId.PointCluster12} {...POINT_CLUSTER_12_SOURCE}>
+        <Layer
+          {...{ ...POINT_CLUSTER_12_STYLE_CIRCLE, filter: categoryFilter }}
+        />
+        <Layer
+          {...{ ...POINT_CLUSTER_12_STYLE_SYMBOL, filter: categoryFilter }}
+        />
+      </Source>
+
+      {/* Single points */}
       <Source id={LayerId.OsmPoint} {...OSM_POINT_SOURCE}>
         <Layer
           {...{
             ...OSM_POINT_LABEL_STYLE,
             layout: {
               ...(OSM_POINT_LABEL_STYLE as SymbolLayer).layout,
-              visibility: mapFiltersContext.getVisibilityValue("pysakointi"),
+              visibility: mapFiltersContext.getVisibilityValue("Pysäköinti"),
             },
           }}
         />
@@ -311,7 +368,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
             ...OSM_AREA_LABEL_STYLE,
             layout: {
               ...(OSM_AREA_LABEL_STYLE as SymbolLayer).layout,
-              visibility: mapFiltersContext.getVisibilityValue("pysakointi"),
+              visibility: mapFiltersContext.getVisibilityValue("Pysäköinti"),
             },
           }}
         />
@@ -369,7 +426,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
             layout: {
               ...(ARCGIS_MUINAISJAANNOS_STYLE_CIRCLE as CircleLayer).layout,
               visibility:
-                mapFiltersContext.getVisibilityValue("muinaisjaannokset"),
+                mapFiltersContext.getVisibilityValue("Muinaisjäännökset"),
             },
           }}
         />
@@ -379,7 +436,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
             layout: {
               ...(ARCGIS_MUINAISJAANNOS_STYLE_SYMBOL as SymbolLayer).layout,
               visibility:
-                mapFiltersContext.getVisibilityValue("muinaisjaannokset"),
+                mapFiltersContext.getVisibilityValue("Muinaisjäännökset"),
             },
           }}
         />
@@ -405,8 +462,8 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
         />
       </Source>
       <Source id={LayerId.LipasPoint} {...LIPAS_POINT_SOURCE}>
-        <Layer {...{ ...LIPAS_POINT_STYLE_CIRCLE, filter: lipasFilter }} />
-        <Layer {...{ ...LIPAS_POINT_STYLE_SYMBOL, filter: lipasFilter }} />
+        <Layer {...{ ...LIPAS_POINT_STYLE_CIRCLE, filter: categoryFilter }} />
+        <Layer {...{ ...LIPAS_POINT_STYLE_SYMBOL, filter: categoryFilter }} />
       </Source>
       {externalData &&
         externalData.get(LayerId.DigiTransitPoint) &&
@@ -422,7 +479,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
                 ...DIGITRANSIT_POINT_STYLE,
                 layout: {
                   ...(DIGITRANSIT_POINT_STYLE as SymbolLayer).layout,
-                  visibility: mapFiltersContext.getVisibilityValue("pysakit"),
+                  visibility: mapFiltersContext.getVisibilityValue("Pysäkit"),
                 },
               }}
             />

--- a/web/src/components/style.ts
+++ b/web/src/components/style.ts
@@ -1,5 +1,11 @@
 import { LayerProps } from "react-map-gl";
-import { Style, VectorSource } from "mapbox-gl";
+import {
+  CirclePaint,
+  LinePaint,
+  Style,
+  SymbolLayout,
+  VectorSource,
+} from "mapbox-gl";
 import { getCategoryIcon } from "../utils";
 import palette from "../theme/palette";
 import { stopType } from "../types";
@@ -20,6 +26,11 @@ export enum LayerId {
   OsmArea = "osm-areas",
   OsmAreaLabel = "osm-areas-labels",
   DigiTransitPoint = "digitransit-points",
+  PointCluster8 = "point-clusters-8",
+  PointCluster9 = "point-clusters-9",
+  PointCluster10 = "point-clusters-10",
+  PointCluster11 = "point-clusters-11",
+  PointCluster12 = "point-clusters-12",
 }
 
 // These are just labels on top of NLS background style
@@ -32,24 +43,6 @@ enum LabelLayerId {
 }
 
 export const NLS_STYLE_URI = "map-styles/nls-style.json";
-
-export const LIPAS_POINT_SOURCE: VectorSource = {
-  type: "vector",
-  tiles: [
-    `${process.env.TILESERVER_URL}/kooste.lipas_pisteet/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20${cityFilterParam}`,
-  ],
-  minzoom: 0,
-  maxzoom: 22,
-};
-
-export const LIPAS_LINE_SOURCE: VectorSource = {
-  type: "vector",
-  tiles: [
-    `${process.env.TILESERVER_URL}/kooste.lipas_viivat/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20${cityFilterParam}`,
-  ],
-  minzoom: 0,
-  maxzoom: 22,
-};
 
 const circleRadius = 12;
 
@@ -92,7 +85,10 @@ watersports_image.src = `${getCategoryIcon("Vesillä ulkoilu")}`;
 const skiing_image: HTMLImageElement = new Image(24, 24);
 skiing_image.src = `${getCategoryIcon("Hiihto")}`;
 
-export const OSM_IMAGES = [
+/**
+ * Images for all symbol layers
+ */
+export const POINT_IMAGES = [
   ["info", info_image],
   ["skating", skating_image],
   ["cycling", cycling_image],
@@ -109,41 +105,131 @@ export const OSM_IMAGES = [
 ];
 
 /**
- * Symbols for lipas points
+ * Layout object for all symbol layers
+ */
+const SYMBOL_LAYOUT: SymbolLayout = {
+  "icon-image": [
+    "match",
+    ["string", ["get", "tarmo_category"]],
+    "Pyöräily",
+    "cycling",
+    "Luistelu",
+    "skating",
+    "Uinti",
+    "swimming",
+    "Ulkoiluaktiviteetit",
+    "activities",
+    "Ulkoilureitit",
+    "trekking",
+    "Laavut, majat, ruokailu",
+    "fireplaces",
+    "Ulkoilupaikat",
+    "outdoors",
+    "Nähtävyydet",
+    "sights",
+    "Muinaisjäännökset",
+    "historical",
+    "Vesillä ulkoilu",
+    "watersports",
+    "Hiihto",
+    "skiing",
+    "info",
+  ],
+  "icon-size": [
+    "match",
+    ["string", ["get", "tarmo_category"]],
+    "Muinaisjäännökset",
+    0.5,
+    0.75,
+  ],
+};
+
+/**
+ * Paint object for all circle layers
+ */
+const CIRCLE_PAINT: CirclePaint = {
+  "circle-radius": circleRadius,
+  "circle-color": [
+    "match",
+    ["string", ["get", "tarmo_category"]],
+    "Pyöräily",
+    "#e8b455",
+    "Luistelu",
+    "#29549a",
+    "Uinti",
+    "#39a7d7",
+    "Ulkoiluaktiviteetit",
+    "#397368",
+    "Ulkoilupaikat",
+    "#397368",
+    "Ulkoilureitit",
+    "#397368",
+    "Laavut, majat, ruokailu",
+    "#ae1e20",
+    "Vesillä ulkoilu",
+    "#39a7d7",
+    "Hiihto",
+    "#5390b5",
+    "Nähtävyydet",
+    "#7361A2",
+    "Muinaisjäännökset",
+    "#00417d",
+    palette.primary.dark,
+  ],
+  "circle-opacity": 0.9,
+};
+
+/**
+ * Paint object for all line layers
+ */
+const LINE_PAINT: LinePaint = {
+  "line-width": 4,
+  "line-color": [
+    "match",
+    ["string", ["get", "tarmo_category"]],
+    "Pyöräily",
+    "#e8b455",
+    "Ulkoilureitit",
+    "#397368",
+    "Vesillä ulkoilu",
+    "#39a7d7",
+    "Hiihto",
+    "#5390b5",
+    palette.primary.dark,
+  ],
+};
+
+/**
+ * Sources for lipas data
+ */
+export const LIPAS_POINT_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.lipas_pisteet/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 0,
+  maxzoom: 22,
+};
+
+export const LIPAS_LINE_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.lipas_viivat/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 0,
+  maxzoom: 22,
+};
+
+/**
+ * Styles for lipas data
  */
 export const LIPAS_POINT_STYLE_SYMBOL: LayerProps = {
   "id": LayerId.LipasPoint,
   "source": LayerId.LipasPoint,
   "source-layer": "kooste.lipas_pisteet",
   "type": "symbol",
-  "layout": {
-    "icon-image": [
-      "match",
-      ["string", ["get", "tarmo_category"]],
-      "Pyöräily",
-      "cycling",
-      "Luistelu",
-      "skating",
-      "Uinti",
-      "swimming",
-      "Ulkoiluaktiviteetit",
-      "activities",
-      "Ulkoilureitit",
-      "trekking",
-      "Laavut, majat, ruokailu",
-      "fireplaces",
-      "Ulkoilupaikat",
-      "outdoors",
-      "Nähtävyydet",
-      "sights",
-      "Vesillä ulkoilu",
-      "watersports",
-      "Hiihto",
-      "skiing",
-      "info",
-    ],
-    "icon-size": 0.75,
-  },
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 11,
 };
 
 export const LIPAS_POINT_STYLE_CIRCLE: LayerProps = {
@@ -151,29 +237,8 @@ export const LIPAS_POINT_STYLE_CIRCLE: LayerProps = {
   "source": LayerId.LipasPoint,
   "source-layer": "kooste.lipas_pisteet",
   "type": "circle",
-  "paint": {
-    "circle-radius": circleRadius,
-    "circle-color": [
-      "match",
-      ["string", ["get", "tarmo_category"]],
-      "Pyöräily",
-      "#e8b455",
-      "Luistelu",
-      "#29549a",
-      "Uinti",
-      "#39a7d7",
-      "Ulkoiluaktiviteetit",
-      "#397368",
-      "Ulkoilupaikat",
-      "#397368",
-      "Laavut, majat, ruokailu",
-      "#ae1e20",
-      "Vesillä ulkoilu",
-      "#39a7d7",
-      palette.primary.dark,
-    ],
-    "circle-opacity": 0.9,
-  },
+  "paint": CIRCLE_PAINT,
+  "minzoom": 11,
 };
 
 export const LIPAS_LINE_STYLE: LayerProps = {
@@ -181,24 +246,12 @@ export const LIPAS_LINE_STYLE: LayerProps = {
   "source": LayerId.LipasLine,
   "source-layer": "kooste.lipas_viivat",
   "type": "line",
-  "paint": {
-    "line-width": 4,
-    "line-color": [
-      "match",
-      ["string", ["get", "tarmo_category"]],
-      "Pyöräily",
-      "#e8b455",
-      "Ulkoilureitit",
-      "#397368",
-      "Vesillä ulkoilu",
-      "#39a7d7",
-      "Hiihto",
-      "#5390b5",
-      palette.primary.dark,
-    ],
-  },
+  "paint": LINE_PAINT,
 };
 
+/**
+ * Sources for WFS data
+ */
 export const WFS_LUONNONMUISTOMERKKI_SOURCE: VectorSource = {
   type: "vector",
   tiles: [
@@ -217,30 +270,25 @@ export const WFS_LUONTOPOLKURASTI_SOURCE: VectorSource = {
   maxzoom: 22,
 };
 
+/**
+ * Styles for WFS data
+ */
 export const WFS_LUONNONMUISTOMERKKI_STYLE_CIRCLE: LayerProps = {
   "id": `${LayerId.WFSLuonnonmuistomerkki}-circle`,
   "source": LayerId.WFSLuonnonmuistomerkki,
   "source-layer": "kooste.tamperewfs_luonnonmuistomerkit",
   "type": "circle",
-  "paint": {
-    "circle-radius": circleRadius,
-    "circle-color": "#397368",
-    "circle-opacity": 0.9,
-  },
+  "paint": CIRCLE_PAINT,
+  "minzoom": 11,
 };
 
-/**
- * WFS Luonnonmuistomerkki symbol
- */
 export const WFS_LUONNONMUISTOMERKKI_STYLE_SYMBOL: LayerProps = {
   "id": LayerId.WFSLuonnonmuistomerkki,
   "source": LayerId.WFSLuonnonmuistomerkki,
   "source-layer": "kooste.tamperewfs_luonnonmuistomerkit",
   "type": "symbol",
-  "layout": {
-    "icon-image": "sights",
-    "icon-size": 0.7,
-  },
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 11,
 };
 
 export const WFS_LUONTOPOLKURASTI_STYLE_CIRCLE: LayerProps = {
@@ -248,27 +296,22 @@ export const WFS_LUONTOPOLKURASTI_STYLE_CIRCLE: LayerProps = {
   "source": LayerId.WFSLuontopolkurasti,
   "source-layer": "kooste.tamperewfs_luontopolkurastit",
   "type": "circle",
-  "paint": {
-    "circle-radius": circleRadius,
-    "circle-color": "#397368",
-    "circle-opacity": 0.9,
-  },
+  "paint": CIRCLE_PAINT,
+  "minzoom": 13,
 };
 
-/**
- * WFS Luontopolkurasti symbol
- */
 export const WFS_LUONTOPOLKURASTI_STYLE_SYMBOL: LayerProps = {
   "id": LayerId.WFSLuontopolkurasti,
   "source": LayerId.WFSLuontopolkurasti,
   "source-layer": "kooste.tamperewfs_luontopolkurastit",
   "type": "symbol",
-  "layout": {
-    "icon-image": "trekking",
-    "icon-size": 0.75,
-  },
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 13,
 };
 
+/**
+ * Sources for ArcGIS data
+ */
 export const ARCGIS_MUINAISJAANNOS_SOURCE: VectorSource = {
   type: "vector",
   tiles: [
@@ -287,30 +330,25 @@ export const ARCGIS_RKYKOHDE_SOURCE: VectorSource = {
   maxzoom: 22,
 };
 
+/**
+ * Styles for ArcGIS data
+ */
 export const ARCGIS_MUINAISJAANNOS_STYLE_CIRCLE: LayerProps = {
   "id": `${LayerId.ArcGisMuinaisjaannos}-circle`,
   "source": LayerId.ArcGisMuinaisjaannos,
   "source-layer": "kooste.museovirastoarcrest_muinaisjaannokset",
   "type": "circle",
-  "paint": {
-    "circle-radius": circleRadius,
-    "circle-color": "#00417d",
-    "circle-opacity": 0.9,
-  },
+  "paint": CIRCLE_PAINT,
+  "minzoom": 13,
 };
 
-/**
- * ARCGIS Muinaisjaannos symbol
- */
 export const ARCGIS_MUINAISJAANNOS_STYLE_SYMBOL: LayerProps = {
   "id": LayerId.ArcGisMuinaisjaannos,
   "source": LayerId.ArcGisMuinaisjaannos,
   "source-layer": "kooste.museovirastoarcrest_muinaisjaannokset",
   "type": "symbol",
-  "layout": {
-    "icon-image": "historical",
-    "icon-size": 0.5,
-  },
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 13,
 };
 
 export const ARCGIS_RKYKOHDE_STYLE_CIRCLE: LayerProps = {
@@ -318,28 +356,22 @@ export const ARCGIS_RKYKOHDE_STYLE_CIRCLE: LayerProps = {
   "source": LayerId.ArcGisRKYkohde,
   "source-layer": "kooste.museovirastoarcrest_rkykohteet",
   "type": "circle",
-  "paint": {
-    "circle-radius": circleRadius,
-    // Circle color is "berry red" from brand book
-    "circle-color": "#ad3963",
-    "circle-opacity": 0.9,
-  },
+  "paint": CIRCLE_PAINT,
+  "minzoom": 11,
 };
 
-/**
- * ARCGIS Rakennettu kulttuurikohde symbol
- */
 export const ARCGIS_RKYKOHDE_STYLE_SYMBOL: LayerProps = {
   "id": LayerId.ArcGisRKYkohde,
   "source": LayerId.ArcGisRKYkohde,
   "source-layer": "kooste.museovirastoarcrest_rkykohteet",
   "type": "symbol",
-  "layout": {
-    "icon-image": "sights",
-    "icon-size": 0.7,
-  },
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 11,
 };
 
+/**
+ * Sources for Syke data
+ */
 export const SYKE_NATURA_SOURCE: VectorSource = {
   type: "vector",
   tiles: [
@@ -349,6 +381,18 @@ export const SYKE_NATURA_SOURCE: VectorSource = {
   maxzoom: 22,
 };
 
+export const SYKE_VALTION_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.syke_valtionluonnonsuojelualueet/{z}/{x}/{y}.pbf?filter=deleted=false`,
+  ],
+  minzoom: 0,
+  maxzoom: 22,
+};
+
+/**
+ * Styles for Syke data
+ */
 export const SYKE_NATURA_STYLE: LayerProps = {
   "id": LayerId.SykeNatura,
   "source": LayerId.SykeNatura,
@@ -358,15 +402,6 @@ export const SYKE_NATURA_STYLE: LayerProps = {
     "fill-color": "#9cbf5f",
     "fill-opacity": 0.2,
   },
-};
-
-export const SYKE_VALTION_SOURCE: VectorSource = {
-  type: "vector",
-  tiles: [
-    `${process.env.TILESERVER_URL}/kooste.syke_valtionluonnonsuojelualueet/{z}/{x}/{y}.pbf?filter=deleted=false`,
-  ],
-  minzoom: 0,
-  maxzoom: 22,
 };
 
 export const SYKE_VALTION_STYLE: LayerProps = {
@@ -380,12 +415,15 @@ export const SYKE_VALTION_STYLE: LayerProps = {
   },
 };
 
+/**
+ * Sources for OSM data
+ */
 export const OSM_POINT_SOURCE: VectorSource = {
   type: "vector",
   tiles: [
     `${process.env.TILESERVER_URL}/kooste.osm_pisteet/{z}/{x}/{y}.pbf?filter=deleted=false`,
   ],
-  minzoom: 13,
+  minzoom: 0,
   maxzoom: 22,
 };
 
@@ -394,10 +432,13 @@ export const OSM_AREA_SOURCE: VectorSource = {
   tiles: [
     `${process.env.TILESERVER_URL}/kooste.osm_alueet/{z}/{x}/{y}.pbf?filter=deleted=false`,
   ],
-  minzoom: 13,
+  minzoom: 0,
   maxzoom: 22,
 };
 
+/**
+ * Styles for OSM data
+ */
 export const OSM_POINT_LABEL_STYLE: LayerProps = {
   "id": LayerId.OsmPoint,
   "source": LayerId.OsmPoint,
@@ -406,6 +447,7 @@ export const OSM_POINT_LABEL_STYLE: LayerProps = {
   "layout": {
     "icon-image": "parking",
   },
+  "minzoom": 14,
 };
 
 export const OSM_AREA_LABEL_STYLE: LayerProps = {
@@ -416,6 +458,7 @@ export const OSM_AREA_LABEL_STYLE: LayerProps = {
   "layout": {
     "icon-image": "parking",
   },
+  "minzoom": 14,
 };
 
 export const OSM_AREA_STYLE: LayerProps = {
@@ -427,8 +470,12 @@ export const OSM_AREA_STYLE: LayerProps = {
     "fill-color": "#0a47a9",
     "fill-opacity": 0.2,
   },
+  "minzoom": 14,
 };
 
+/**
+ * Images for Digitransit data
+ */
 const digiTransitImageIds: Array<string> = Object.values(stopType);
 const images: Array<HTMLImageElement> = digiTransitImageIds.map(
   () => new Image(24, 24)
@@ -443,6 +490,9 @@ DIGITRANSIT_IMAGES.forEach(
   (tuple: any) => (tuple[1].src = `/img/${tuple[0]}.png`)
 );
 
+/**
+ * Styles for Digitransit data
+ */
 export const DIGITRANSIT_POINT_STYLE: LayerProps = {
   id: LayerId.DigiTransitPoint,
   source: LayerId.DigiTransitPoint,
@@ -450,8 +500,166 @@ export const DIGITRANSIT_POINT_STYLE: LayerProps = {
   layout: {
     "icon-image": ["get", "type"],
   },
+  minzoom: 14,
 };
 
+/**
+ * Point cluster layers by zoom level
+ */
+const CLUSTER_CIRCLE_PAINT = {
+  // we want clusters to be more imposing, if not outright humongous
+  ...CIRCLE_PAINT,
+  "circle-radius": 1.7 * circleRadius,
+};
+
+export const POINT_CLUSTER_8_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.point_clusters_8/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20visibility=true%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 2,
+  maxzoom: 9,
+};
+
+export const POINT_CLUSTER_8_STYLE_CIRCLE: LayerProps = {
+  "id": `${LayerId.PointCluster8}-circle`,
+  "source": LayerId.PointCluster8,
+  "source-layer": "kooste.point_clusters_8",
+  "type": "circle",
+  "paint": CLUSTER_CIRCLE_PAINT,
+  "minzoom": 2,
+  "maxzoom": 9,
+};
+
+export const POINT_CLUSTER_8_STYLE_SYMBOL: LayerProps = {
+  "id": `${LayerId.PointCluster8}`,
+  "source": LayerId.PointCluster8,
+  "source-layer": "kooste.point_clusters_8",
+  "type": "symbol",
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 2,
+  "maxzoom": 9,
+};
+
+export const POINT_CLUSTER_9_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.point_clusters_9/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20visibility=true%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 9,
+  maxzoom: 10,
+};
+
+export const POINT_CLUSTER_9_STYLE_CIRCLE: LayerProps = {
+  "id": `${LayerId.PointCluster9}-circle`,
+  "source": LayerId.PointCluster9,
+  "source-layer": "kooste.point_clusters_9",
+  "type": "circle",
+  "paint": CLUSTER_CIRCLE_PAINT,
+  "minzoom": 9,
+  "maxzoom": 10,
+};
+
+export const POINT_CLUSTER_9_STYLE_SYMBOL: LayerProps = {
+  "id": `${LayerId.PointCluster9}`,
+  "source": LayerId.PointCluster9,
+  "source-layer": "kooste.point_clusters_9",
+  "type": "symbol",
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 9,
+  "maxzoom": 10,
+};
+
+export const POINT_CLUSTER_10_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.point_clusters_10/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20visibility=true%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 10,
+  maxzoom: 11,
+};
+
+export const POINT_CLUSTER_10_STYLE_CIRCLE: LayerProps = {
+  "id": `${LayerId.PointCluster10}-circle`,
+  "source": LayerId.PointCluster10,
+  "source-layer": "kooste.point_clusters_10",
+  "type": "circle",
+  "paint": CLUSTER_CIRCLE_PAINT,
+  "minzoom": 10,
+  "maxzoom": 11,
+};
+
+export const POINT_CLUSTER_10_STYLE_SYMBOL: LayerProps = {
+  "id": `${LayerId.PointCluster10}`,
+  "source": LayerId.PointCluster10,
+  "source-layer": "kooste.point_clusters_10",
+  "type": "symbol",
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 10,
+  "maxzoom": 11,
+};
+
+export const POINT_CLUSTER_11_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.point_clusters_11/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20visibility=true%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 11,
+  maxzoom: 12,
+};
+
+export const POINT_CLUSTER_11_STYLE_CIRCLE: LayerProps = {
+  "id": `${LayerId.PointCluster11}-circle`,
+  "source": LayerId.PointCluster11,
+  "source-layer": "kooste.point_clusters_11",
+  "type": "circle",
+  "paint": CLUSTER_CIRCLE_PAINT,
+  "minzoom": 11,
+  "maxzoom": 12,
+};
+
+export const POINT_CLUSTER_11_STYLE_SYMBOL: LayerProps = {
+  "id": `${LayerId.PointCluster11}`,
+  "source": LayerId.PointCluster11,
+  "source-layer": "kooste.point_clusters_11",
+  "type": "symbol",
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 11,
+  "maxzoom": 12,
+};
+
+export const POINT_CLUSTER_12_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.point_clusters_12/{z}/{x}/{y}.pbf?filter=deleted=false%20AND%20visibility=true%20AND%20${cityFilterParam}`,
+  ],
+  minzoom: 12,
+  maxzoom: 13,
+};
+
+export const POINT_CLUSTER_12_STYLE_CIRCLE: LayerProps = {
+  "id": `${LayerId.PointCluster12}-circle`,
+  "source": LayerId.PointCluster12,
+  "source-layer": "kooste.point_clusters_12",
+  "type": "circle",
+  "paint": CLUSTER_CIRCLE_PAINT,
+  "minzoom": 12,
+  "maxzoom": 13,
+};
+
+export const POINT_CLUSTER_12_STYLE_SYMBOL: LayerProps = {
+  "id": `${LayerId.PointCluster12}`,
+  "source": LayerId.PointCluster12,
+  "source-layer": "kooste.point_clusters_12",
+  "type": "symbol",
+  "layout": SYMBOL_LAYOUT,
+  "minzoom": 12,
+  "maxzoom": 13,
+};
+
+/**
+ * Styles for map labels
+ */
 export const NLS_LABEL_STYLE: LayerProps = {
   "id": LabelLayerId.NLSLabel,
   "type": "symbol",
@@ -498,6 +706,7 @@ export const NLS_LABEL_STYLE: LayerProps = {
     "text-color": "rgba(68, 68, 68, 1)",
     "text-halo-blur": 1,
   },
+  "minzoom": 12,
 };
 
 export const NLS_KUNNAT_LABEL_STYLE: LayerProps = {
@@ -638,6 +847,9 @@ export const NLS_TIET_LABEL_STYLE: LayerProps = {
   },
 };
 
+/**
+ * Extra background map styles
+ */
 export const NLS_TERRAIN_STYLE: Style = {
   name: "Maastokartta",
   version: 8,

--- a/web/src/contexts/MapFiltersContext.tsx
+++ b/web/src/contexts/MapFiltersContext.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 /**
- * Lipas filters
+ * Category filters
  */
-export const LIPAS_FILTERS = Object.freeze({
+export const CATEGORY_FILTERS = Object.freeze({
   "Pyöräily": true,
   "Luistelu": true,
   "Uinti": true,
@@ -14,35 +14,23 @@ export const LIPAS_FILTERS = Object.freeze({
   "Nähtävyydet": true,
   "Vesillä ulkoilu": true,
   "Hiihto": true,
+  "Pysäköinti": true,
+  "Pysäkit": true,
+  "Muinaisjäännökset": true,
 });
 
 /**
- * Map filters
+ * Type for category filters
  */
-export const MAP_FILTERS = Object.freeze({
-  ...LIPAS_FILTERS,
-  pysakointi: true,
-  pysakit: true,
-  muinaisjaannokset: true,
-});
+export type CategoryFilters = typeof CATEGORY_FILTERS;
 
 /**
- * Type for Lipas filters
+ * Category map layer filter
  */
-export type LipasFilters = typeof LIPAS_FILTERS;
-
-/**
- * Type for all map filters
- */
-export type MapFilters = typeof MAP_FILTERS;
-
-/**
- * Lipas map layer filter
- */
-type LipasLayerFilter = [
+type CategoryLayerFilter = [
   "match",
   ["get", "tarmo_category"],
-  (keyof LipasFilters | "")[],
+  (keyof CategoryFilters | "")[],
   true,
   false
 ];
@@ -56,12 +44,12 @@ type VisibilityValue = "none" | "visible";
  * Map filters context type
  */
 export interface MapFiltersContextType {
-  filters: MapFilters;
-  setFilters: (filters: MapFilters) => void;
-  toggleFilter: (key: keyof MapFilters) => void;
-  getLipasFilter: () => LipasLayerFilter;
-  getFilterValue: (key: keyof MapFilters) => boolean;
-  getVisibilityValue: (key: keyof MapFilters) => VisibilityValue;
+  filters: CategoryFilters;
+  setFilters: (filters: CategoryFilters) => void;
+  toggleFilter: (key: keyof CategoryFilters) => void;
+  getCategoryFilter: () => CategoryLayerFilter;
+  getFilterValue: (key: keyof CategoryFilters) => boolean;
+  getVisibilityValue: (key: keyof CategoryFilters) => VisibilityValue;
 }
 
 /**
@@ -75,10 +63,16 @@ interface Props {
  * Map filters context initialization
  */
 export const MapFiltersContext = React.createContext<MapFiltersContextType>({
-  filters: MAP_FILTERS,
+  filters: CATEGORY_FILTERS,
   setFilters: () => undefined,
   toggleFilter: () => undefined,
-  getLipasFilter: () => ["match", ["get", "tarmo_category"], [], true, false],
+  getCategoryFilter: () => [
+    "match",
+    ["get", "tarmo_category"],
+    [],
+    true,
+    false,
+  ],
   getFilterValue: () => false,
   getVisibilityValue: () => "visible",
 });
@@ -89,25 +83,27 @@ export const MapFiltersContext = React.createContext<MapFiltersContextType>({
  * @param props component properties
  */
 export default function MapFiltersProvider({ children }: Props) {
-  const [filters, setFilters] = React.useState<MapFilters>({ ...MAP_FILTERS });
+  const [filters, setFilters] = React.useState<CategoryFilters>({
+    ...CATEGORY_FILTERS,
+  });
 
   /**
    * Toggles single filter with given key
    *
    * @param key key
    */
-  const toggleFilter = (key: keyof MapFilters) =>
+  const toggleFilter = (key: keyof CategoryFilters) =>
     setFilters({ ...filters, [key]: !filters[key] });
 
   /**
-   * Returns filter value for Lipas map layer
+   * Returns filter value for all map layers
    */
-  const getLipasFilter = (): LipasLayerFilter => {
-    const lipasFilterEntries = Object.entries(filters);
-    const includedEntries = lipasFilterEntries.filter(([, value]) => !!value);
+  const getCategoryFilter = (): CategoryLayerFilter => {
+    const mapFilterEntries = Object.entries(filters);
+    const includedEntries = mapFilterEntries.filter(([, value]) => !!value);
     const filterLabels = includedEntries.map(
       ([key]) => key
-    ) as (keyof LipasFilters)[];
+    ) as (keyof CategoryFilters)[];
 
     return [
       "match",
@@ -123,14 +119,14 @@ export default function MapFiltersProvider({ children }: Props) {
    *
    * @param key filter key
    */
-  const getFilterValue = (key: keyof MapFilters) => ({ ...filters }[key]);
+  const getFilterValue = (key: keyof CategoryFilters) => ({ ...filters }[key]);
 
   /**
    * Returns value of given filter as layer visibility value
    *
    * @param key filter key
    */
-  const getVisibilityValue = (key: keyof MapFilters): VisibilityValue =>
+  const getVisibilityValue = (key: keyof CategoryFilters): VisibilityValue =>
     ({ ...filters }[key] ? "visible" : "none");
 
   /**
@@ -140,7 +136,7 @@ export default function MapFiltersProvider({ children }: Props) {
     filters: filters,
     setFilters: setFilters,
     toggleFilter: toggleFilter,
-    getLipasFilter: getLipasFilter,
+    getCategoryFilter: getCategoryFilter,
     getFilterValue: getFilterValue,
     getVisibilityValue: getVisibilityValue,
   };

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -81,3 +81,27 @@ export const getCategoryIcon = (category: string) =>
     "Ratikkapysäkki": "img/tram.png",
     "Muinaisjäännökset": "img/historical-light.png",
   }[category]);
+
+/**
+ * Get category plural partitive
+ * @param category
+ * @returns category name in plural partitive
+ */
+export const getCategoryPlural = (category: string) =>
+  ({
+    "Hiihto": "hiihtokohdetta",
+    "Luistelu": "luistelupaikkaa",
+    "Ulkoilupaikat": "ulkoilupaikkaa",
+    "Ulkoiluaktiviteetit": "ulkoiluaktiviteettia",
+    "Ulkoilureitit": "ulkoilureittikohdetta",
+    "Pyöräily": "pyöräilykohdetta",
+    "Laavut, majat, ruokailu": "laavua, majaa tai ruokailupaikkaa",
+    "Vesillä ulkoilu": "vesilläulkoilukohdetta",
+    "Nähtävyydet": "nähtävyyttä",
+    "Uinti": "uintipaikkaa",
+    "Pysäköinti": "pysäköintipaikkaa",
+    "Bussipysäkki": "bussipysäkkiä",
+    "Rautatieasema": "rautatieasemaa",
+    "Ratikkapysäkki": "ratikkapysäkkiä",
+    "Muinaisjäännökset": "muinaisjäännöstä",
+  }[category]);


### PR DESCRIPTION
Had to make each cluster zoom level its own source and layer. This is because

1) they come from different sources, and MapLibre source or source id of a layer cannot be changed on the fly, and

2) they must have different ids, and MapLibre layer id cannot be changed on the fly. MapLibre gets terribly confused with data if ids are not static.