### PR TITLE
Try disabling filters when zoomed out

### DIFF
--- a/web/src/components/LayerFilter.tsx
+++ b/web/src/components/LayerFilter.tsx
@@ -22,9 +22,14 @@ import RightSidePanel from "./RightSidePanel";
 import { FilterList } from "@mui/icons-material";
 import theme from "../theme/theme";
 
+interface LayerFilterProps {
+  zoom: number;
+}
+
 type Category = {
   name: keyof CategoryFilters;
   icon: string;
+  zoomThreshold?: number;
 };
 
 const categories: Category[] = [
@@ -61,16 +66,18 @@ const categories: Category[] = [
     icon: "camera-darkwater.png",
   },
   {
+    name: "Muinaisjäännökset",
+    icon: "historical-dark.png",
+  },
+  {
     name: "Pysäköinti",
     icon: "parking-darkwater.png",
+    zoomThreshold: 13,
   },
   {
     name: "Pysäkit",
     icon: "bus-darkwater.png",
-  },
-  {
-    name: "Muinaisjäännökset",
-    icon: "historical-dark.png",
+    zoomThreshold: 13,
   },
 ];
 
@@ -90,7 +97,7 @@ const winterCategories: Category[] = [
  *
  * @returns filter to control the visible layers
  */
-export default function LayerFilter() {
+export default function LayerFilter(props: LayerFilterProps) {
   const mapFiltersContext = React.useContext(MapFiltersContext);
   const [open, setOpen] = React.useState(false);
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -126,7 +133,8 @@ export default function LayerFilter() {
    * @param icon Category icon
    * @returns
    */
-  const renderCategoryFilter = (name: keyof CategoryFilters, icon: string) => {
+  const renderCategoryFilter = (name: keyof CategoryFilters, icon: string, zoomThreshold?: number) => {
+    const disabled = !!zoomThreshold && props.zoom < zoomThreshold
     return (
       <ListItem key={name} divider>
         <ListItemAvatar>
@@ -137,8 +145,9 @@ export default function LayerFilter() {
             flex: 1,
             justifyContent: "space-between",
           }}
-          label={name}
+          label={name + (zoomThreshold ? " lähialueella" : "")}
           labelPlacement="start"
+          disabled={disabled}
           control={
             <Switch
               name={name}
@@ -158,7 +167,7 @@ export default function LayerFilter() {
   const renderCategories = () => {
     return (
       <>
-        {categories.map(({ name, icon }) => renderCategoryFilter(name, icon))}
+        {categories.map(({ name, icon, zoomThreshold }) => renderCategoryFilter(name, icon, zoomThreshold))}
       </>
     );
   };

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -106,7 +106,7 @@ export default function TarmoMap({
       {
         url: "https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql",
         tarmo_category: "Pysäkit",
-        zoomThreshold: 12,
+        zoomThreshold: 13,
         reload: true,
         gqlQuery: `{
         stopsByBbox(minLat: $minLat, minLon: $minLon, maxLat: $maxLat, maxLon: $maxLon ) {
@@ -130,7 +130,7 @@ export default function TarmoMap({
       {
         url: "https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql",
         tarmo_category: "Pysäkit",
-        zoomThreshold: 12,
+        zoomThreshold: 13,
         reload: false,
         gqlQuery: `{
           bikeRentalStations {
@@ -638,7 +638,7 @@ export default function TarmoMap({
           <InfoButton />
           <NavigationControl />
           <GeolocateControl trackUserLocation={true} />
-          <LayerFilter />
+          <LayerFilter zoom={zoom}/>
         </>
       )}
     </MapGL>

--- a/web/src/components/style.ts
+++ b/web/src/components/style.ts
@@ -309,7 +309,7 @@ export const OSM_POINT_LABEL_STYLE: LayerProps = {
   "layout": {
     "icon-image": ["get", "amenity"],
   },
-  "minzoom": 14,
+  "minzoom": 13,
 };
 
 export const OSM_AREA_LABEL_STYLE: LayerProps = {
@@ -320,7 +320,7 @@ export const OSM_AREA_LABEL_STYLE: LayerProps = {
   "layout": {
     "icon-image": ["get", "amenity"],
   },
-  "minzoom": 14,
+  "minzoom": 13,
 };
 
 export const OSM_AREA_STYLE: LayerProps = {
@@ -332,7 +332,7 @@ export const OSM_AREA_STYLE: LayerProps = {
     "fill-color": "#0a47a9",
     "fill-opacity": 0.2,
   },
-  "minzoom": 14,
+  "minzoom": 13,
 };
 
 /**
@@ -362,7 +362,7 @@ export const DIGITRANSIT_POINT_STYLE: LayerProps = {
   layout: {
     "icon-image": ["get", "type"],
   },
-  minzoom: 12,
+  minzoom: 13,
 };
 export const DIGITRANSIT_BIKE_POINT_STYLE: LayerProps = {
   id: LayerId.DigiTransitBikePoint,
@@ -372,7 +372,7 @@ export const DIGITRANSIT_BIKE_POINT_STYLE: LayerProps = {
     "icon-image": "bike",
     "icon-allow-overlap": true,
   },
-  minzoom: 12,
+  minzoom: 13,
 };
 
 /**


### PR DESCRIPTION
Try addressing #178 .

Clustering might not be very useful due to the huge amount of parking lots all over the place. Plus digitransit stops cannot be fetched that far out anyway, we don't want to spam the Digitransit API with too many calls with a huge bbox.