### PR TITLE
Map height set to match viewport

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,6 @@ import { PopupInfo } from "./types";
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
   const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
-  const viewHeight = window.innerHeight;
 
   useEffect(() => {
     // Show splash screen for 2s on startup
@@ -27,7 +26,7 @@ export default function App() {
   return showSplash ? (
     <SplashScreen />
   ) : (
-    <Box sx={{ position: "fixed", width: "100%", height: viewHeight }}>
+    <Box sx={{ width: "100vw", height: "100vh" }}>
       <MapFiltersProvider>
         <TarmoMap setPopupInfo={setPopupInfo} />
       </MapFiltersProvider>

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -359,7 +359,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): JSX.Element {
         bearing: 0,
         pitch: 0,
       }}
-      style={{ width: "100%", height: "100%" }}
+      style={{ width: "100vw", height: "100vh" }}
       mapLib={maplibregl}
       mapStyle={mapStyle}
       onResize={toggleNav}

--- a/web/src/components/RightSidePanel.tsx
+++ b/web/src/components/RightSidePanel.tsx
@@ -1,6 +1,7 @@
-import { ChevronRight, Close } from "@mui/icons-material";
+import { ChevronRight } from "@mui/icons-material";
 import {
   Box,
+  Button,
   IconButton,
   styled,
   Toolbar,
@@ -38,6 +39,8 @@ const StyledToolbar = styled(Toolbar)(() => ({
 const Wrapper = styled(Box)(({ theme }) => ({
   position: "relative",
   overflow: "hidden",
+  width: "100vw",
+  height: "100vh",
   [theme.breakpoints.up("md")]: {
     width: 400,
   },
@@ -53,6 +56,7 @@ const Container = styled(Box)(() => ({
   maxWidth: "100%",
   maxHeight: "calc(100% - 64px)",
   overflowX: "auto",
+  flex: 1,
   WebkitOverflowScrolling: "touch", // iOS momentum scrolling
 }));
 
@@ -76,9 +80,15 @@ export default function RightSidePanel({
           {title}
         </Typography>
         {mobile ? (
-          <IconButton onClick={onClose} color="primary" sx={{ mr: -1 }}>
-            <Close />
-          </IconButton>
+          <Button
+            onClick={onClose}
+            color="primary"
+            variant="text"
+            endIcon={<ChevronRight /> }
+            sx={{ mr: -1 }}
+          >
+            Piilota
+          </Button>
         ) : (
           <Tooltip title="Piilota paneeli">
             <IconButton onClick={onClose} color="primary" sx={{ mr: -1 }}>


### PR DESCRIPTION
- hide panel button more clear that it "hides" the right side panel on mobile devices

Since the mobile users never sees the map when typing on search panel, the previous height adjustments are unnecessary. Height is now always the viewport's height. Mobile browser keyboard temporarily reduces the height and caused the map to move when keyboard was visible.