### PR TITLE
202 add lines to search

### DIFF
--- a/backend/databasemodel/alembic/versions/6b21865a7058/downgrade.sql
+++ b/backend/databasemodel/alembic/versions/6b21865a7058/downgrade.sql
@@ -2,5 +2,14 @@ DROP INDEX kooste.lipas_viivat_name_idx;
 DROP INDEX kooste.lipas_viivat_tarmo_category_idx;
 DROP INDEX kooste.lipas_viivat_type_name_idx;
 DROP INDEX kooste.all_points_tarmo_category_idx;
-DROP INDEX kooste.all_points_viivat_type_name_idx;
+DROP INDEX kooste.all_points_type_name_idx;
+
+drop materialized view kooste.all_points;
+create materialized view kooste.all_points as
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('lipas_pisteet-', "sportsPlaceId") as id, "name", "cityName", "tarmo_category", 'lipas_pisteet' as table_name, row_to_json(points)::jsonb as props from kooste.lipas_pisteet as points where deleted=false union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_rkykohteet-', "OBJECTID") as id, "name", 'Tampere' as "cityName", "tarmo_category", 'museovirastoarcrest_rkykohteet' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_rkykohteet as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_muinaisjaannokset-', "mjtunnus") as id, "name", "cityName", "tarmo_category", 'museovirastoarcrest_muinaisjaannokset' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_muinaisjaannokset as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luonnonmuistomerkit-', "sw_member") as id, "name", 'Tampere' as "cityName", "tarmo_category", 'tamperewfs_luonnonmuistomerkit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luonnonmuistomerkit as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luontopolkurastit-', "mi_prinx") as id ,"name", 'Tampere' as "cityName", "tarmo_category", 'tamperewfs_luontopolkurastit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luontopolkurastit as points where deleted=false and visibility=true;
+
 CREATE INDEX ON kooste.lipas_viivat (tarmo_category);

--- a/backend/databasemodel/alembic/versions/6b21865a7058/downgrade.sql
+++ b/backend/databasemodel/alembic/versions/6b21865a7058/downgrade.sql
@@ -1,0 +1,6 @@
+DROP INDEX kooste.lipas_viivat_name_idx;
+DROP INDEX kooste.lipas_viivat_tarmo_category_idx;
+DROP INDEX kooste.lipas_viivat_type_name_idx;
+DROP INDEX kooste.all_points_tarmo_category_idx;
+DROP INDEX kooste.all_points_viivat_type_name_idx;
+CREATE INDEX ON kooste.lipas_viivat (tarmo_category);

--- a/backend/databasemodel/alembic/versions/6b21865a7058/upgrade.sql
+++ b/backend/databasemodel/alembic/versions/6b21865a7058/upgrade.sql
@@ -1,0 +1,6 @@
+DROP INDEX kooste.lipas_viivat_tarmo_category_idx;
+CREATE INDEX ON kooste.lipas_viivat USING gin (name gin_trgm_ops);
+CREATE INDEX ON kooste.lipas_viivat USING gin ("tarmo_category" gin_trgm_ops);
+CREATE INDEX ON kooste.lipas_viivat USING gin ("type_name" gin_trgm_ops);
+create index on kooste.all_points USING gin ("tarmo_category" gin_trgm_ops);
+create index on kooste.all_points USING gin ("type_name" gin_trgm_ops);

--- a/backend/databasemodel/alembic/versions/6b21865a7058/upgrade.sql
+++ b/backend/databasemodel/alembic/versions/6b21865a7058/upgrade.sql
@@ -1,6 +1,14 @@
+drop materialized view kooste.all_points;
+create materialized view kooste.all_points as
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('lipas_pisteet-', "sportsPlaceId") as id, "name", "cityName", "tarmo_category", "type_name", 'lipas_pisteet' as table_name, row_to_json(points)::jsonb as props from kooste.lipas_pisteet as points where deleted=false union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_rkykohteet-', "OBJECTID") as id, "name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'museovirastoarcrest_rkykohteet' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_rkykohteet as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_muinaisjaannokset-', "mjtunnus") as id, "name", "cityName", "tarmo_category", "type_name", 'museovirastoarcrest_muinaisjaannokset' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_muinaisjaannokset as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luonnonmuistomerkit-', "sw_member") as id, "name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'tamperewfs_luonnonmuistomerkit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luonnonmuistomerkit as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luontopolkurastit-', "mi_prinx") as id ,"name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'tamperewfs_luontopolkurastit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luontopolkurastit as points where deleted=false and visibility=true;
+
 DROP INDEX kooste.lipas_viivat_tarmo_category_idx;
 CREATE INDEX ON kooste.lipas_viivat USING gin (name gin_trgm_ops);
 CREATE INDEX ON kooste.lipas_viivat USING gin ("tarmo_category" gin_trgm_ops);
 CREATE INDEX ON kooste.lipas_viivat USING gin ("type_name" gin_trgm_ops);
-create index on kooste.all_points USING gin ("tarmo_category" gin_trgm_ops);
-create index on kooste.all_points USING gin ("type_name" gin_trgm_ops);
+CREATE INDEX ON kooste.all_points USING gin ("tarmo_category" gin_trgm_ops);
+CREATE INDEX ON kooste.all_points USING gin ("type_name" gin_trgm_ops);

--- a/backend/databasemodel/alembic/versions/6b21865a7058_add_viivat_name_index.py
+++ b/backend/databasemodel/alembic/versions/6b21865a7058_add_viivat_name_index.py
@@ -1,0 +1,37 @@
+"""add viivat name index
+
+Revision ID: 6b21865a7058
+Revises: 7443e8ba2d75
+Create Date: 2022-06-23 17:43:15.729442
+
+"""
+import os
+
+from alembic import op
+
+here = os.path.dirname(os.path.realpath(__file__))
+
+# revision identifiers, used by Alembic.
+revision = "6b21865a7058"
+down_revision = "7443e8ba2d75"
+branch_labels = None
+depends_on = None
+
+revision_dir = f"{here}/{revision}"
+
+
+# idea from https://github.com/tbobm/alembic-sequeled
+def process_migration(script_name: str):
+    filename = f"{revision_dir}/{script_name}.sql"
+
+    query = "\n".join(open(filename))
+    if len(query) > 0:
+        op.execute(query)
+
+
+def upgrade():
+    process_migration("upgrade")
+
+
+def downgrade():
+    process_migration("downgrade")

--- a/backend/databasemodel/model.sql
+++ b/backend/databasemodel/model.sql
@@ -1395,7 +1395,10 @@ CREATE TABLE kooste.lipas_viivat (
 	CONSTRAINT lipas_viivat_pk PRIMARY KEY ("sportsPlaceId")
 );
 CREATE INDEX ON kooste.lipas_viivat (deleted);
-CREATE INDEX ON kooste.lipas_viivat (tarmo_category);
+-- Use the trigram extension to speed up text search
+CREATE INDEX ON kooste.lipas_viivat USING gin (name gin_trgm_ops);
+CREATE INDEX ON kooste.lipas_viivat USING gin ("tarmo_category" gin_trgm_ops);
+CREATE INDEX ON kooste.lipas_viivat USING gin ("type_name" gin_trgm_ops);
 CREATE INDEX lipas_viivat_cityname_idx ON kooste.lipas_viivat ("cityName");
 -- ddl-end --
 ALTER TABLE kooste.lipas_viivat OWNER TO tarmo_admin;
@@ -2092,17 +2095,18 @@ GRANT USAGE
 -- ddl-end --
 
 create materialized view kooste.all_points as
-select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('lipas_pisteet-', "sportsPlaceId") as id, "name", "cityName", "tarmo_category", 'lipas_pisteet' as table_name, row_to_json(points)::jsonb as props from kooste.lipas_pisteet as points where deleted=false union all
-select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_rkykohteet-', "OBJECTID") as id, "name", 'Tampere' as "cityName", "tarmo_category", 'museovirastoarcrest_rkykohteet' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_rkykohteet as points where deleted=false and visibility=true union all
-select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_muinaisjaannokset-', "mjtunnus") as id, "name", "cityName", "tarmo_category", 'museovirastoarcrest_muinaisjaannokset' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_muinaisjaannokset as points where deleted=false and visibility=true union all
-select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luonnonmuistomerkit-', "sw_member") as id, "name", 'Tampere' as "cityName", "tarmo_category", 'tamperewfs_luonnonmuistomerkit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luonnonmuistomerkit as points where deleted=false and visibility=true union all
-select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luontopolkurastit-', "mi_prinx") as id ,"name", 'Tampere' as "cityName", "tarmo_category", 'tamperewfs_luontopolkurastit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luontopolkurastit as points where deleted=false and visibility=true;
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('lipas_pisteet-', "sportsPlaceId") as id, "name", "cityName", "tarmo_category", "type_name", 'lipas_pisteet' as table_name, row_to_json(points)::jsonb as props from kooste.lipas_pisteet as points where deleted=false union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_rkykohteet-', "OBJECTID") as id, "name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'museovirastoarcrest_rkykohteet' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_rkykohteet as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('museovirastoarcrest_muinaisjaannokset-', "mjtunnus") as id, "name", "cityName", "tarmo_category", "type_name", 'museovirastoarcrest_muinaisjaannokset' as table_name, row_to_json(points)::jsonb as props from kooste.museovirastoarcrest_muinaisjaannokset as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luonnonmuistomerkit-', "sw_member") as id, "name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'tamperewfs_luonnonmuistomerkit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luonnonmuistomerkit as points where deleted=false and visibility=true union all
+select ST_GeometryN(geom,1)::geometry(point,4326) as geom, CONCAT('tamperewfs_luontopolkurastit-', "mi_prinx") as id ,"name", 'Tampere' as "cityName", "tarmo_category", "type_name", 'tamperewfs_luontopolkurastit' as table_name, row_to_json(points)::jsonb as props from kooste.tamperewfs_luontopolkurastit as points where deleted=false and visibility=true;
 
 create index on kooste.all_points (id);
 -- Use the trigram extension to speed up text search
 create index on kooste.all_points USING gin (name gin_trgm_ops);
+create index on kooste.all_points USING gin ("tarmo_category" gin_trgm_ops);
+create index on kooste.all_points USING gin ("type_name" gin_trgm_ops);
 create index on kooste.all_points ("cityName");
-create index on kooste.all_points ("tarmo_category");
 
 ALTER TABLE kooste.all_points OWNER TO tarmo_read_write;
 

--- a/web/src/components/SearchMenu.tsx
+++ b/web/src/components/SearchMenu.tsx
@@ -26,7 +26,8 @@ import WithDebounce from "../utils/WithDebounce";
 
 interface SearchMenuProps {
   searchString: string;
-  searchResults: Map<string, MapboxGeoJSONFeature>;
+  searchPoints: Map<string, MapboxGeoJSONFeature>;
+  searchLines: Map<string, MapboxGeoJSONFeature>;
   stringSetter: (string: string) => void;
   selectedSetter: (string: string) => void;
 }
@@ -142,11 +143,13 @@ export default function SearchMenu(props: SearchMenuProps) {
    * Render result list
    */
   const renderResultList = () => {
-    const results = Array.from(props.searchResults.entries());
-
-    if (!props.searchResults || !props.searchString) {
+    if (!props.searchString) {
       return null;
     }
+
+    const points = Array.from(props.searchPoints.entries());
+    const lines = Array.from(props.searchLines.entries());
+    const results = [...lines, ...points]
 
     if (props.searchString && results.length < 1) {
       return (

--- a/web/src/components/style.ts
+++ b/web/src/components/style.ts
@@ -29,7 +29,8 @@ export enum LayerId {
   PointCluster11 = "point-clusters-11",
   PointCluster12 = "point-clusters-12",
   PointCluster13 = "point-clusters-13",
-  Search = "search",
+  SearchPoint = "search-points",
+  SearchLine = "search-lines",
 }
 
 // These are just labels on top of NLS background style
@@ -419,29 +420,51 @@ export const POINT_STYLE_CIRCLE: LayerProps = {
  * used to search for the input string when zoomed in.
  */
 
-export const SEARCH_SOURCE: VectorSource = {
+export const SEARCH_POINT_SOURCE: VectorSource = {
   type: "vector",
   tiles: [
-    `${process.env.TILESERVER_URL}/kooste.all_points/{z}/{x}/{y}.pbf?filter=${cityFilterParam}%20AND%20name%20ILIKE%20`,
+    `${process.env.TILESERVER_URL}/kooste.all_points/{z}/{x}/{y}.pbf?filter=${cityFilterParam}%20AND%20(name%20ILIKE%20'%25{searchString}%25'%20OR%20type_name%20ILIKE%20'%25{searchString}%25'%20OR%20tarmo_category%20ILIKE%20'%25{searchString}%25')`,
   ],
   minzoom: 0,
   maxzoom: 6,
 };
 
 export const SEARCH_STYLE_SYMBOL: LayerProps = {
-  "id": LayerId.Search,
-  "source": LayerId.Search,
+  "id": LayerId.SearchPoint,
+  "source": LayerId.SearchPoint,
   "source-layer": "kooste.all_points",
   "type": "symbol",
   "layout": SYMBOL_LAYOUT,
 };
 
 export const SEARCH_STYLE_CIRCLE: LayerProps = {
-  "id": `${LayerId.Search}-circle`,
-  "source": LayerId.Search,
+  "id": `${LayerId.SearchPoint}-circle`,
+  "source": LayerId.SearchPoint,
   "source-layer": "kooste.all_points",
   "type": "circle",
   "paint": CIRCLE_PAINT,
+};
+
+/**
+ * Dynamic search line layer. Maxzoom defines the size of the tile
+ * used to search for the input string when zoomed in.
+ */
+
+ export const SEARCH_LINE_SOURCE: VectorSource = {
+  type: "vector",
+  tiles: [
+    `${process.env.TILESERVER_URL}/kooste.lipas_viivat/{z}/{x}/{y}.pbf?filter=${cityFilterParam}%20AND%20(name%20ILIKE%20'%25{searchString}%25'%20OR%20type_name%20ILIKE%20'%25{searchString}%25'%20OR%20tarmo_category%20ILIKE%20'%25{searchString}%25')`,
+  ],
+  minzoom: 0,
+  maxzoom: 8,
+};
+
+export const SEARCH_LINE_STYLE: LayerProps = {
+  "id": LayerId.SearchLine,
+  "source": LayerId.SearchLine,
+  "source-layer": "kooste.lipas_viivat",
+  "type": "line",
+  "paint": LINE_PAINT,
 };
 
 /**


### PR DESCRIPTION
Fix #202 

Also, with this PR, also type names and tarmo categories are searched. This way, e.g. "latu" also returns all skiing tracks (even if the name does not contain "latu"), "pyörä" finds the meager 4 bike routes in existence, "luontotorni" finds birdwatching towers, etc.