### PR TITLE
Fix React 19 map and debounce initialization

### DIFF
--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -88,6 +88,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): React.JSX.Ele
   const mapFiltersContext = useContext(MapFiltersContext);
   const [mapStyle, setMapStyle] = useState<Style | undefined>(undefined);
   const [showNav, setShowNav] = useState(true);
+  const [mapLoaded, setMapLoaded] = useState(false);
   const [zoom, setZoom] = useState(10);
   const [bounds, setBounds] = useState<Bbox | null>(null);
   const [externalData, setExternalData] =
@@ -416,6 +417,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): React.JSX.Ele
       style={{ width: "100vw", height: "100vh" }}
       mapLib={maplibregl}
       mapStyle={mapStyle}
+      onLoad={() => setMapLoaded(true)}
       onResize={toggleNav}
       styleDiffing={false}
     >
@@ -697,10 +699,12 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): React.JSX.Ele
         selectedSetter={setSelected}
       />
       <FullscreenControl />
-      <ScaleControl
-        maxWidth={200}
-        style={{ borderRadius: "0px", backgroundColor: "#ffffff20" }}
-      />
+      {mapLoaded && (
+        <ScaleControl
+          maxWidth={200}
+          style={{ borderRadius: "0px", backgroundColor: "#ffffff20" }}
+        />
+      )}
       {showNav && (
         <>
           <LayerPicker setter={setLayer} />

--- a/web/src/components/SearchMenu.tsx
+++ b/web/src/components/SearchMenu.tsx
@@ -207,7 +207,6 @@ export default function SearchMenu(props: SearchMenuProps) {
           <Box pl={3} pr={3}>
             <WithDebounce
               debounceTimeout={1000}
-              key="haku"
               value={props.searchString}
               onChange={handleChange}
               component={inputProps => (

--- a/web/src/utils/WithDebounce.tsx
+++ b/web/src/utils/WithDebounce.tsx
@@ -6,7 +6,6 @@ import * as React from "react";
 interface Props {
   className?: string;
   component: (props: DebounceProps) => React.ReactElement;
-  key?: string | number;
   disabled?: boolean;
   name?: string;
   label?: string;
@@ -19,7 +18,6 @@ interface Props {
  * Interface representing debounce properties given to render function
  */
 interface DebounceProps {
-  key?: string | number;
   disabled?: boolean;
   name?: string;
   label?: string;
@@ -38,7 +36,6 @@ const WithDebounce: React.FC<Props> = ({
   value,
   className,
   debounceTimeout,
-  key,
   onChange,
   component,
 }) => {
@@ -77,7 +74,6 @@ const WithDebounce: React.FC<Props> = ({
     disabled: disabled,
     value: inputValue,
     className: className,
-    key: key,
     label: label,
     onChange: onInputChange,
   });

--- a/web/test/WithDebounce.test.tsx
+++ b/web/test/WithDebounce.test.tsx
@@ -65,4 +65,21 @@ describe("WithDebounce", () => {
 
     expect((input as HTMLInputElement).value).toBe("from parent");
   });
+
+  it("does not access React's reserved key prop", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <WithDebounce
+        key="search-input"
+        component={props => <input {...props} />}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
- Delay ScaleControl rendering until the MapLibre map has loaded.
- Remove the invalid reserved key prop usage from WithDebounce.
- Remove the unused key="haku" prop from SearchMenu.

Previously, _WithDebounce_ accessed React’s reserved key prop. The added test renders the exact scenario and verifies that no warning is logged, so future changes cannot accidentally reintroduce the same problem.