### PR TITLE
Fix React 19 map control initialization

### DIFF
--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -701,6 +701,7 @@ export default function TarmoMap({ setPopupInfo }: TarmoMapProps): React.JSX.Ele
       <FullscreenControl />
       {mapLoaded && (
         <ScaleControl
+          unit="metric"
           maxWidth={200}
           style={{ borderRadius: "0px", backgroundColor: "#ffffff20" }}
         />

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -23,7 +23,7 @@
 
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0 maximum-scale=1.0 user-scalable=0 shrink-to-fit=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, shrink-to-fit=no"
     />
 
     <!-- Using Google Font -->


### PR DESCRIPTION
- Fix the ScaleControl crash in React 19 by passing its default unit explicitly
- Correct the viewport metadata separators